### PR TITLE
feat: add focus event

### DIFF
--- a/demo/text-fit.html
+++ b/demo/text-fit.html
@@ -28,6 +28,18 @@
 			      $scope.$broadcast('textFit')
 			    })
 			  }
+			  
+			  $scope.timeoutTest = function(){
+				  $timeout( function(){
+
+					  $scope.height = 400
+					  $scope.width = 600
+					  $scope.$broadcast('textFit')	  
+					  
+				  }, 5000)
+
+				  
+			  }
 			})			
 			
 		</script>
@@ -59,6 +71,8 @@
 		  Padding: <input type="number" ng-model="padding" ng-change="doStuff()" ng-model-options="{debounce: 500}"/><br/>
 		  Text In Box 1: <input ng-model="myText1"/> 
 		  Console Output: <input type="checkbox" ng-model="consoleOut" ng-change="doStuff()" ng-model-options="{debounce: 500}" ng-true-value="'info'">
+		  <br>
+		  <button ng-click="timeoutTest()">$timeout Test</button> this will wait 10 seconds, then resize the H x W and then rerun textfit. Used to test if when you refocus the browser window, will it work.
 		  <hr/>
 		  <h1>With good first guess</h1>
 		    <div ng-style="{height: height+'px', width: width+'px'}" class="my-box">

--- a/dist/angular-gizmos.js
+++ b/dist/angular-gizmos.js
@@ -626,7 +626,7 @@ angular.module("gizmos.directives").directive("imageSrc", ["Config", function (C
   };
 }]);
 // Directive textFit attaches textFit behavior to an element. 
-angular.module("gizmos.directives").directive("textFit", ["$timeout", "textFit", "$parse", function ($timeout, textFit, $parse) {
+angular.module("gizmos.directives").directive("textFit", ["$timeout", "$window", "textFit", function ($timeout, $window, textFit) {
   return {
     restrict: "A",
     scope: {
@@ -645,8 +645,20 @@ angular.module("gizmos.directives").directive("textFit", ["$timeout", "textFit",
         }
 
         $scope.$watch("text", onTextChange);
-        $scope.$on("$destroy", deregisterFn || angular.noop);
         $scope.$on("textFit", onTextChange);
+
+        // Add focus event to trigger textfit
+        $window.addEventListener("focus", onTextChange);
+
+        // Deregister on destroy
+        $scope.$on("$destroy", function () {
+
+          if (textFitGroup) {
+            deregisterFn();
+          }
+
+          $window.removeEventListener("focus", onTextChange);
+        });
       };
 
       // When the text changes, update the element's text and rerun textFit.
@@ -768,7 +780,7 @@ angular.module("gizmos.directives").directive("textFitGroup", ["$timeout", "$par
 //   on the shouldWarn parameter.  This allows the caller to retry again later,
 //   perhaps after the element has become visible.
 angular.module("gizmos.directives").value("textFit", function textFit(element, options, shouldWarn) {
-  var min, max, mid, lastMid, containerStyle, containerWidth, containerHeight, projectedPercentageOfBox, accuracy, allowWordWrap, debug;
+  var min, max, mid, lastMid, containerStyle, containerWidth, containerHeight, accuracy, allowWordWrap, debug;
 
   debug = function () {
     for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {

--- a/dist/directives/text-fit/text-fit.js
+++ b/dist/directives/text-fit/text-fit.js
@@ -1,5 +1,5 @@
 // Directive textFit attaches textFit behavior to an element. 
-angular.module("gizmos.directives").directive("textFit", ["$timeout", "textFit", "$parse", function ($timeout, textFit, $parse) {
+angular.module("gizmos.directives").directive("textFit", ["$timeout", "$window", "textFit", function ($timeout, $window, textFit) {
   return {
     restrict: "A",
     scope: {
@@ -18,8 +18,20 @@ angular.module("gizmos.directives").directive("textFit", ["$timeout", "textFit",
         }
 
         $scope.$watch("text", onTextChange);
-        $scope.$on("$destroy", deregisterFn || angular.noop);
         $scope.$on("textFit", onTextChange);
+
+        // Add focus event to trigger textfit
+        $window.addEventListener("focus", onTextChange);
+
+        // Deregister on destroy
+        $scope.$on("$destroy", function () {
+
+          if (textFitGroup) {
+            deregisterFn();
+          }
+
+          $window.removeEventListener("focus", onTextChange);
+        });
       };
 
       // When the text changes, update the element's text and rerun textFit.
@@ -141,7 +153,7 @@ angular.module("gizmos.directives").directive("textFitGroup", ["$timeout", "$par
 //   on the shouldWarn parameter.  This allows the caller to retry again later,
 //   perhaps after the element has become visible.
 angular.module("gizmos.directives").value("textFit", function textFit(element, options, shouldWarn) {
-  var min, max, mid, lastMid, containerStyle, containerWidth, containerHeight, projectedPercentageOfBox, accuracy, allowWordWrap, debug;
+  var min, max, mid, lastMid, containerStyle, containerWidth, containerHeight, accuracy, allowWordWrap, debug;
 
   debug = function () {
     for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {

--- a/src/directives/text-fit/text-fit-directive.js
+++ b/src/directives/text-fit/text-fit-directive.js
@@ -1,5 +1,5 @@
 // Directive textFit attaches textFit behavior to an element.  
-angular.module( 'gizmos.directives' ).directive( 'textFit', function( $timeout, textFit, $parse ) {
+angular.module( 'gizmos.directives' ).directive( 'textFit', function( $timeout,  $window, textFit ) {
   return {
     restrict: 'A',
     scope: {
@@ -18,8 +18,21 @@ angular.module( 'gizmos.directives' ).directive( 'textFit', function( $timeout, 
         }
 
         $scope.$watch( 'text', onTextChange )
-        $scope.$on( '$destroy', deregisterFn || angular.noop )
         $scope.$on( 'textFit', onTextChange )
+        
+        // Add focus event to trigger textfit
+        $window.addEventListener('focus', onTextChange)
+        
+        // Deregister on destroy
+        $scope.$on( '$destroy', () => {
+          
+            if( textFitGroup ) {
+              deregisterFn()
+            } 
+            
+            $window.removeEventListener('focus', onTextChange)
+          
+          })
       }
 
       // When the text changes, update the element's text and rerun textFit.

--- a/src/directives/text-fit/text-fit.js
+++ b/src/directives/text-fit/text-fit.js
@@ -14,7 +14,7 @@
 //   on the shouldWarn parameter.  This allows the caller to retry again later,
 //   perhaps after the element has become visible.
 angular.module( 'gizmos.directives' ).value( 'textFit', function textFit( element, options, shouldWarn ) {
-  var min, max, mid, lastMid, containerStyle, containerWidth, containerHeight, projectedPercentageOfBox, accuracy, allowWordWrap, debug
+  var min, max, mid, lastMid, containerStyle, containerWidth, containerHeight, accuracy, allowWordWrap, debug
   
   debug = function ( ...args ) {
 


### PR DESCRIPTION
Certain browsers will not render UI when in an unfocused state. So we will trigger the textFit to run whenever the window is brought into focus. 

this should fix https://github.com/HalfTime/queue-web-client/issues/665

this also cleans up code. 

NO BREAKING CHANGES.
