### PR TITLE
fix(text-fit): tweaks for better height

### DIFF
--- a/src/directives/text-fit/text-fit.js
+++ b/src/directives/text-fit/text-fit.js
@@ -60,7 +60,7 @@ angular.module( 'gizmos.directives' ).value( 'textFit', function textFit( elemen
 
   // Min and max font size.
   min = options.min || 6
-  max = Math.min(containerHeight, (options.max || 120) );
+  max = Math.min( Math.max(containerHeight, containerWidth), (options.max || 120) );
   mid = Math.floor( ( min + max ) / 2 * 10 ) / 10
   
   // Do a binary search for the best font size
@@ -71,7 +71,7 @@ angular.module( 'gizmos.directives' ).value( 'textFit', function textFit( elemen
 
     // Use scrollWidth because it checks for overflow text
     var width = element[0].scrollWidth
-    var height = element[0].offsetHeight
+    var height = element[0].scrollHeight
     var isTooBig = ( height > containerHeight || width > containerWidth )
     
     debug( '[textFit] %sx%s in %sx%s. %s < (%s) < %s - %s', width, height, containerWidth, containerHeight, min, mid, max, isTooBig ? 'too big' : 'too small' )


### PR DESCRIPTION
No breaking changes. This handles heights better when the text starts out bigger than its parent container. 
